### PR TITLE
Add containerErrorStyle props

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ export default function Demo() {
 
 # FileViewer Props
 
-| Prop name        |  Type |  Description |
-|--------------|:-----:|-----------:|
-| src      |  string | The url of the file to be previewed |
-| mimetype      |  string (optional) | Used to specify the mimetype of the file and determine how to preview the url, alternatively filename can be used |
-| filename      |  string (optional) | The file extension is used to specify the mimetype of the file and determine how to preview the url, alternatively mimetype can be used |
-| loader |  ReactNode (optional) | A loader to replace the default loader used by the project |
-| onError      |  (e: any) => void (optional) | A callback that can be used to detect if an error has occurred in the loading of the files|
-| autoPlay | boolean | To autoplay a video or an audio
+| Prop name        |            Type             |  Description |
+|--------------|:---------------------------:|-----------:|
+| src      |           string            | The url of the file to be previewed |
+| mimetype      |      string (optional)      | Used to specify the mimetype of the file and determine how to preview the url, alternatively filename can be used |
+| filename      |      string (optional)      | The file extension is used to specify the mimetype of the file and determine how to preview the url, alternatively mimetype can be used |
+| loader |    ReactNode (optional)     | A loader to replace the default loader used by the project |
+| onError      | (e: any) => void (optional) | A callback that can be used to detect if an error has occurred in the loading of the files|
+| autoPlay |           boolean           | To autoplay a video or an audio
+| containerErrorStyle |     React.CSSProperties     | The style of the container when an error occurs

--- a/src/file-viewer.tsx
+++ b/src/file-viewer.tsx
@@ -56,12 +56,11 @@ export default function FileViewer({
     return (
       <div
         style={
-          containerErrorStyle
-            ? containerErrorStyle
-            : {
-                width: '50px',
-                height: '50px',
-              }
+          {
+          width: '50px',
+          height: '50px',
+          ...(containerErrorStyle || {})
+        }
         }
       >
         <FileIcon

--- a/src/file-viewer.tsx
+++ b/src/file-viewer.tsx
@@ -5,6 +5,7 @@ import Loading from './components/loading'
 import styled from 'styled-components'
 import { FileIcon, defaultStyles } from 'react-file-icon'
 import { DefaultExtensionType } from 'react-file-icon'
+
 interface Props {
   loader?: React.ReactNode
   mimeType?: string
@@ -12,6 +13,7 @@ interface Props {
   src: string
   onError?: (e: any) => void
   autoPlay?: boolean
+  containerErrorStyle?: React.CSSProperties
 }
 
 const Container = styled.div`
@@ -21,7 +23,15 @@ const Container = styled.div`
   align-items: center;
   background-color: white;
 `
-export default function FileViewer({ loader = <Loading />, mimeType, src, onError, fileName, autoPlay }: Props) {
+export default function FileViewer({
+  loader = <Loading />,
+  mimeType,
+  src,
+  onError,
+  fileName,
+  autoPlay,
+  containerErrorStyle,
+}: Props) {
   const [showError, setShowError] = useState(false)
   const [showLoading, setShowLoading] = useState(false)
   const [fileType, setFileType] = useState('')
@@ -45,10 +55,14 @@ export default function FileViewer({ loader = <Loading />, mimeType, src, onErro
   if (showError) {
     return (
       <div
-        style={{
-          width: '50px',
-          height: '50px',
-        }}
+        style={
+          containerErrorStyle
+            ? containerErrorStyle
+            : {
+                width: '50px',
+                height: '50px',
+              }
+        }
       >
         <FileIcon
           extension={MimeTypes.getExtension(fileType) ?? ''}


### PR DESCRIPTION
I encountered an issue where, if an image was unavailable, an icon showing the file extension would be displayed. However, the icon would overflow the container, which had dimensions of height: 50px and width: 50px, causing layout issues. To address this, I added a containerErrorStyle property, allowing custom styles to ensure the icon fits properly within the container.